### PR TITLE
Add Authorization header with Bearer token from jwtToken cookie

### DIFF
--- a/admin/src/components/ExportModal/ExportModal.jsx
+++ b/admin/src/components/ExportModal/ExportModal.jsx
@@ -15,6 +15,7 @@ import { useLocalStorage } from '../../hooks/useLocalStorage';
 import { useSlug } from '../../hooks/useSlug';
 import { dataFormatConfigs, dataFormats } from '../../utils/dataFormats';
 import { handleRequestErr } from '../../utils/error';
+import { getAuthHeaders } from '../../utils/auth';
 import { Editor } from '../Editor';
 
 const DEFAULT_OPTIONS = {
@@ -60,7 +61,7 @@ export const ExportModal = ({ availableExportFormats = [dataFormats.CSV, dataFor
           deepness: options.deepness,
           exportPluginsContentTypes: options.exportPluginsContentTypes,
         }
-      });
+      }, { headers: getAuthHeaders() });
       setData(res.data);
     } catch (err) {
       console.log('err', err);

--- a/admin/src/components/ImportModal/ImportModal.jsx
+++ b/admin/src/components/ImportModal/ImportModal.jsx
@@ -70,6 +70,7 @@ import { useI18n } from '../../hooks/useI18n';
 import { useSlug } from '../../hooks/useSlug';
 import { dataFormats } from '../../utils/dataFormats.js';
 import { handleRequestErr } from '../../utils/error.js';
+import { getAuthHeaders } from '../../utils/auth';
 import getTrad from '../../utils/getTrad';
 
 import { Editor } from '../Editor/Editor.jsx';
@@ -147,12 +148,8 @@ export const ImportModal = ({ onClose }) => {
     try {
       const { post } = fetchClient;
       const res = await post(`/${PLUGIN_ID}/import`, {
-        // body: JSON.stringify({ slug, data, format: dataFormat, ...options }),
         data:{ slug, data, format: dataFormat, ...options },
-        // headers: {
-        //   'Content-Type': 'application/json',
-        // },
-      });
+      }, { headers: getAuthHeaders() });
 
       const { failures } = res;
       if (!failures.length) {

--- a/admin/src/components/ImportModal/components/ImportEditor/ImportEditor.jsx
+++ b/admin/src/components/ImportModal/components/ImportEditor/ImportEditor.jsx
@@ -5,6 +5,7 @@ import { PLUGIN_ID } from '../../../../pluginId'; // Ensure PLUGIN_ID is correct
 
 import { useForm } from '../../../../hooks/useForm';
 import { useI18n } from '../../../../hooks/useI18n';
+import { getAuthHeaders } from '../../../../utils/auth';
 import { Editor } from '../../../Editor/Editor';
 
 export const ImportEditor = ({ file, data, dataFormat, slug, onDataChanged, onOptionsChanged }) => {
@@ -19,7 +20,7 @@ export const ImportEditor = ({ file, data, dataFormat, slug, onDataChanged, onOp
       const { get } = fetchClient;
       console.log('slug', slug);
       try {
-        const resData = await get(`/${PLUGIN_ID}/import/model-attributes/${slug}`);
+        const resData = await get(`/${PLUGIN_ID}/import/model-attributes/${slug}`, { headers: getAuthHeaders() });
         console.log('resData', resData);
         setAttributeNames(resData?.data?.data?.attribute_names);
       } catch (error) {

--- a/admin/src/utils/auth.js
+++ b/admin/src/utils/auth.js
@@ -1,0 +1,16 @@
+export const getToken = () => {
+  const match = document.cookie.match(/(?:^|;\s*)jwtToken=([^;]*)/);
+  if (match) {
+    try {
+      return JSON.parse(decodeURIComponent(match[1]));
+    } catch {
+      return decodeURIComponent(match[1]);
+    }
+  }
+  return '';
+};
+
+export const getAuthHeaders = () => {
+  const token = getToken();
+  return token ? { Authorization: `Bearer ${token}` } : {};
+};


### PR DESCRIPTION
  Strapi's built-in useFetchClient reads the JWT from localStorage/sessionStorage,
  but the token is stored in a cookie, resulting in empty Authorization headers
  and 401 errors. Added a utility that reads the jwtToken cookie and passes it
  as a custom Authorization header on all plugin API requests.